### PR TITLE
Fix README Pushover variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ To receive push notifications on your phone or device:
 1. Create a free account at [Pushover](https://pushover.net/) and install the app on your device.
 2. Get your **User Key** and create an **Application/API Token**.
 3. Set these values in your `config.py` or as environment variables:
-   - `PUSHOVER_USER_KEY`
-   - `PUSHOVER_API_TOKEN`
+   - `PUSHOVER_TOKEN` *(application token)*
+   - `PUSHOVER_USER` *(user key)*
 4. Enable Pushover notifications in the settings.
 
 You will now receive alerts for CPU/RAM thresholds and container status changes directly to your device.


### PR DESCRIPTION
## Summary
- fix Pushover instructions to use `PUSHOVER_TOKEN` and `PUSHOVER_USER`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684030d154b8832e8d08892c5cea07ce