### PR TITLE
Make React interface default

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Once running, open your browser and go to:
 http://localhost:5001
 ```
 
+The main UI uses a React front-end for a modern user experience.
+
 Use the **Server IP** field (and "Use Custom IP" checkbox) in the UI to point the links to another host if needed.
 
 ---

--- a/routes.py
+++ b/routes.py
@@ -138,21 +138,16 @@ def require_auth():
 # --- Ruta Index ---
 @main_routes.route('/')
 def index():
-    """Sirve la página HTML principal."""
-    print("DEBUG: Sirviendo página index.html") # Añadido para depuración
+    """Serve the modern React-based interface."""
     csrf_token = generate_csrf_token()
-    # Detectar número de cores de CPU
-    cpu_cores = multiprocessing.cpu_count()
-    max_cpu_percent = cpu_cores * 100
-    # Obtener RAM total del host usando Docker API
-    try:
-        from docker_client import get_docker_client
-        info = get_docker_client().info()
-        max_ram_mb = int(info.get('MemTotal', 0)) // (1024 * 1024)
-    except Exception as e:
-        print(f"WARN: No se pudo obtener la RAM total del host desde Docker API: {e}")
-        max_ram_mb = None
-    return render_template('index.html', csrf_token=csrf_token, cpu_cores=cpu_cores, max_cpu_percent=max_cpu_percent, max_ram_mb=max_ram_mb)
+    return render_template('react.html', csrf_token=csrf_token)
+
+@main_routes.route('/react')
+def react_ui():
+    """Serve the minimal React-based interface."""
+    csrf_token = generate_csrf_token()
+    return render_template('react.html', csrf_token=csrf_token)
+
 
 def get_cadvisor_metrics():
     """Obtiene métricas de cAdvisor para todos los contenedores."""

--- a/templates/react.html
+++ b/templates/react.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Docker Monitor React UI</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect } = React;
+
+    function DockerTable() {
+      const [containers, setContainers] = useState([]);
+      const [loading, setLoading] = useState(true);
+
+      useEffect(() => {
+        fetch('/api/metrics')
+          .then(res => res.json())
+          .then(data => {
+            setContainers(data);
+            setLoading(false);
+          })
+          .catch(err => {
+            console.error(err);
+            setLoading(false);
+          });
+      }, []);
+
+      if (loading) {
+        return <div className="text-center mt-5">Loading...</div>;
+      }
+
+      return (
+        <div className="container mt-4">
+          <h2 className="mb-4 text-center">Docker Containers</h2>
+          <table className="table table-striped">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>CPU %</th>
+                <th>RAM %</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {containers.map(c => (
+                <tr key={c.id}>
+                  <td>{c.name}</td>
+                  <td>{c.cpu !== null ? c.cpu.toFixed(2) : 'N/A'}</td>
+                  <td>{c.mem !== null ? c.mem.toFixed(2) : 'N/A'}</td>
+                  <td>{c.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<DockerTable />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- make React UI the default interface on '/'
- document React UI as main interface

## Testing
- `python3 -m py_compile routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684033304f10832ea7cf796e8c7daa68