### PR TITLE
Persist notification settings

### DIFF
--- a/sampler.py
+++ b/sampler.py
@@ -22,6 +22,7 @@ from metrics_utils import (
     calc_block_io
 )
 from pushover_client import send as push_notify
+from users_db import get_notification_settings, set_notification_settings
 
 # Configure basic logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -47,15 +48,15 @@ force_update_check_ids = set()
 
 # --- Notification System ---
 notifications = collections.deque(maxlen=500)  # Store recent notification events
-notification_settings = {
+notification_settings = get_notification_settings({
     'cpu_enabled': True,
     'ram_enabled': True,
     'status_enabled': True,
     'update_enabled': True,
     'cpu_threshold': 80.0,
     'ram_threshold': 80.0,
-    'window_seconds': 10,  # How long the threshold must be exceeded
-}
+    'window_seconds': 10,
+})
 # Track when each container last exceeded threshold
 cpu_exceed_start = {}
 ram_exceed_start = {}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2534,9 +2534,36 @@
             });
         })();
 
-        // Load saved notification settings ONLY on initial load
+        // Load saved notification settings and sync from backend
         document.getElementById('notifCpuThreshold').value = localStorage.getItem('notifCpuThreshold') || 80;
         document.getElementById('notifRamThreshold').value = localStorage.getItem('notifRamThreshold') || 80;
+        fetch('/api/notification-settings')
+          .then(res => res.json())
+          .then(settings => {
+            if (settings) {
+              if (settings.cpu_threshold !== undefined) {
+                document.getElementById('notifCpuThreshold').value = settings.cpu_threshold;
+                localStorage.setItem('notifCpuThreshold', settings.cpu_threshold);
+              }
+              if (settings.ram_threshold !== undefined) {
+                document.getElementById('notifRamThreshold').value = settings.ram_threshold;
+                localStorage.setItem('notifRamThreshold', settings.ram_threshold);
+              }
+              if (settings.window_seconds !== undefined) {
+                document.getElementById('notifWindowSeconds').value = settings.window_seconds;
+                localStorage.setItem('notifWindowSeconds', settings.window_seconds);
+              }
+              document.getElementById('notifEnableCPU').checked = settings.cpu_enabled;
+              document.getElementById('notifEnableRAM').checked = settings.ram_enabled;
+              document.getElementById('notifEnableStatus').checked = settings.status_enabled;
+              document.getElementById('notifEnableUpdate').checked = settings.update_enabled;
+              localStorage.setItem('notifEnableCPU', settings.cpu_enabled);
+              localStorage.setItem('notifEnableRAM', settings.ram_enabled);
+              localStorage.setItem('notifEnableStatus', settings.status_enabled);
+              localStorage.setItem('notifEnableUpdate', settings.update_enabled);
+            }
+          })
+          .catch(() => {});
 
         // Setup notification toggle button
         document.getElementById('notifToggle').addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- create global settings table
- expose API to get/set notification settings
- load notification settings from backend on page load
- persist settings to database

## Testing
- `python -m py_compile users_db.py routes.py sampler.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_68417092de9c832e8730df112ca15eec