### PR TITLE
Add iOS SwiftUI client

### DIFF
--- a/ios_app/.gitignore
+++ b/ios_app/.gitignore
@@ -1,0 +1,1 @@
+*.xcuserdata

--- a/ios_app/Package.swift
+++ b/ios_app/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:5.5
+import PackageDescription
+
+let package = Package(
+    name: "DockerStatsApp",
+    platforms: [.iOS(.v15)],
+    products: [
+        .executable(name: "DockerStatsApp", targets: ["DockerStatsApp"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "DockerStatsApp",
+            path: "Sources"
+        )
+    ]
+)

--- a/ios_app/README.md
+++ b/ios_app/README.md
@@ -1,0 +1,13 @@
+# DockerStats iOS Client
+
+This directory contains a minimal SwiftUI application that can be used as a client for the DockerStats backend.
+
+The app lets the user configure the backend URL and optional reverse proxy credentials. It verifies the connection and stores the configuration in the Keychain/`UserDefaults`. After a successful connection it displays the list of containers with all reported statistics.
+
+## Building
+
+1. Open Xcode and choose **File > Open...**. Select the `ios_app` folder.
+2. Build and run the `DockerStatsApp` target on iOS 15 or later.
+3. Enter your backend URL and credentials. Once connected, the container list will appear.
+
+The project does not include any external dependencies.

--- a/ios_app/Sources/ContainerListView.swift
+++ b/ios_app/Sources/ContainerListView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// Displays a list of containers with all metrics from the server.
+struct ContainerListView: View {
+    let serverURL: URL
+    let username: String?
+    let password: String?
+
+    @State private var containers: [ContainerStats] = []
+    @State private var loading = true
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            if loading {
+                ProgressView().frame(maxWidth: .infinity, alignment: .center)
+            }
+            ForEach(containers) { item in
+                ContainerRow(stats: item)
+            }
+            if let msg = errorMessage {
+                Text(msg).foregroundColor(.red)
+            }
+        }
+        .navigationTitle("Containers")
+        .onAppear(perform: fetch)
+    }
+
+    private func fetch() {
+        loading = true
+        NetworkManager.shared.fetchMetrics(url: serverURL, username: username, password: password) { result in
+            loading = false
+            switch result {
+            case .success(let rows):
+                containers = rows
+            case .failure(let err):
+                errorMessage = err.localizedDescription
+            }
+        }
+    }
+}
+
+/// Displays metrics for a single container.
+struct ContainerRow: View {
+    let stats: ContainerStats
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(stats.name).font(.headline)
+            HStack {
+                Text("CPU: \(format(stats.cpu))%")
+                Text("RAM: \(format(stats.mem))%")
+                Text("PIDs: \(stats.pid_count ?? 0)")
+            }
+            HStack {
+                Text("Net RX: \(format(stats.net_io_rx))MB")
+                Text("Net TX: \(format(stats.net_io_tx))MB")
+                Text("Restarts: \(stats.restarts ?? 0)")
+            }
+            HStack {
+                Text("Image: \(stats.image ?? "")")
+            }
+        }
+    }
+
+    private func format(_ value: Double?) -> String {
+        guard let v = value else { return "-" }
+        return String(format: "%.2f", v)
+    }
+}
+
+struct ContainerListView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContainerListView(serverURL: URL(string: "http://localhost:5001")!, username: nil, password: nil)
+    }
+}

--- a/ios_app/Sources/ContainerStats.swift
+++ b/ios_app/Sources/ContainerStats.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Representation of a container row from `/api/metrics`.
+struct ContainerStats: Identifiable, Decodable {
+    let id: String
+    let name: String
+    let pid_count: Int?
+    let mem_limit: Double?
+    let mem_usage: Double?
+    let cpu: Double?
+    let mem: Double?
+    let combined: Double?
+    let status: String?
+    let uptime: String?
+    let net_io_rx: Double?
+    let net_io_tx: Double?
+    let block_io_r: Double?
+    let block_io_w: Double?
+    let image: String?
+    let ports: String?
+    let restarts: Int?
+    let update_available: Bool?
+    let compose_project: String?
+    let compose_service: String?
+    let gpu: String?
+    let gpu_max: Double?
+}

--- a/ios_app/Sources/ContentView.swift
+++ b/ios_app/Sources/ContentView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+struct ContentView: View {
+    @State private var serverURL: String = UserDefaults.standard.string(forKey: "serverURL") ?? "http://localhost:5001/"
+    @State private var username: String = UserDefaults.standard.string(forKey: "username") ?? ""
+    @State private var password: String = KeychainManager.loadPassword(account: "dockerstats_password") ?? ""
+    @State private var statusMessage: String = ""
+    @State private var connecting = false
+    @State private var showMetrics = false
+
+    var body: some View {
+        NavigationView {
+            if showMetrics {
+                ContainerListView(serverURL: URL(string: serverURL)!, username: username, password: password)
+            } else {
+                Form {
+                    Section(header: Text("Server")) {
+                        TextField("URL", text: $serverURL)
+                            .keyboardType(.URL)
+                            .autocapitalization(.none)
+                    }
+                    Section(header: Text("Credentials (optional)")) {
+                        TextField("Username", text: $username)
+                            .autocapitalization(.none)
+                        SecureField("Password", text: $password)
+                    }
+                    Section {
+                        Button(action: connect) {
+                            if connecting {
+                                ProgressView()
+                            } else {
+                                Text("Connect")
+                            }
+                        }
+                    }
+                    if !statusMessage.isEmpty {
+                        Section {
+                            Text(statusMessage).foregroundColor(.red)
+                        }
+                    }
+                }
+                .navigationTitle("DockerStats Setup")
+            }
+        }
+    }
+
+    private func connect() {
+        guard let url = URL(string: serverURL) else {
+            statusMessage = "Invalid URL"
+            return
+        }
+        connecting = true
+        NetworkManager.shared.verifyConnection(url: url, username: username, password: password) { result in
+            connecting = false
+            switch result {
+            case .success:
+                UserDefaults.standard.set(serverURL, forKey: "serverURL")
+                UserDefaults.standard.set(username, forKey: "username")
+                if !password.isEmpty { _ = KeychainManager.save(password: password, for: "dockerstats_password") }
+                statusMessage = "Connection successful"
+                showMetrics = true
+            case .failure(let error):
+                statusMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/ios_app/Sources/DockerStatsApp.swift
+++ b/ios_app/Sources/DockerStatsApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct DockerStatsApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/ios_app/Sources/KeychainManager.swift
+++ b/ios_app/Sources/KeychainManager.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Security
+
+/// Simple wrapper around Keychain services for storing credentials.
+struct KeychainManager {
+    static func save(password: String, for account: String) -> Bool {
+        guard let data = password.data(using: .utf8) else { return false }
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data
+        ]
+        SecItemDelete(query as CFDictionary) // Remove existing item
+        return SecItemAdd(query as CFDictionary, nil) == errSecSuccess
+    }
+
+    static func loadPassword(account: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/ios_app/Sources/NetworkManager.swift
+++ b/ios_app/Sources/NetworkManager.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Handles communication with the DockerStats backend.
+class NetworkManager: ObservableObject {
+    /// Shared instance for use across views.
+    static let shared = NetworkManager()
+
+    /// Test connection to the server using the provided URL and credentials.
+    func verifyConnection(url: URL, username: String?, password: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+        var request = URLRequest(url: url.appendingPathComponent("api/metrics"))
+        if let user = username, let pass = password, !user.isEmpty, !pass.isEmpty {
+            let credential = "\(user):\(pass)".data(using: .utf8)!.base64EncodedString()
+            request.setValue("Basic \(credential)", forHTTPHeaderField: "Authorization")
+        }
+
+        URLSession.shared.dataTask(with: request) { _, response, error in
+            if let error = error {
+                DispatchQueue.main.async { completion(.failure(error)) }
+                return
+            }
+            guard let http = response as? HTTPURLResponse else {
+                DispatchQueue.main.async { completion(.failure(NSError(domain: "No response", code: -1, userInfo: nil))) }
+                return
+            }
+            if http.statusCode == 200 {
+                DispatchQueue.main.async { completion(.success(())) }
+            } else if http.statusCode == 401 {
+                let err = NSError(domain: "InvalidCredentials", code: 401, userInfo: [NSLocalizedDescriptionKey: "Invalid credentials"]) 
+                DispatchQueue.main.async { completion(.failure(err)) }
+            } else {
+                let err = NSError(domain: "HTTP", code: http.statusCode, userInfo: [NSLocalizedDescriptionKey: "Server responded with status \(http.statusCode)"])
+                DispatchQueue.main.async { completion(.failure(err)) }
+            }
+        }.resume()
+    }
+
+    /// Retrieve container metrics from the server.
+    func fetchMetrics(url: URL, username: String?, password: String?, completion: @escaping (Result<[ContainerStats], Error>) -> Void) {
+        var request = URLRequest(url: url.appendingPathComponent("api/metrics"))
+        if let user = username, let pass = password, !user.isEmpty, !pass.isEmpty {
+            let credential = "\(user):\(pass)".data(using: .utf8)!.base64EncodedString()
+            request.setValue("Basic \(credential)", forHTTPHeaderField: "Authorization")
+        }
+
+        URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                DispatchQueue.main.async { completion(.failure(error)) }
+                return
+            }
+            guard let data = data else {
+                DispatchQueue.main.async { completion(.failure(NSError(domain: "No data", code: -1, userInfo: nil))) }
+                return
+            }
+            do {
+                let decoder = JSONDecoder()
+                let metrics = try decoder.decode([ContainerStats].self, from: data)
+                DispatchQueue.main.async { completion(.success(metrics)) }
+            } catch {
+                DispatchQueue.main.async { completion(.failure(error)) }
+            }
+        }.resume()
+    }
+}


### PR DESCRIPTION
## Summary
- create `ios_app` directory with SwiftUI source files
- implement Keychain support for storing credentials
- add network layer to validate server connection and fetch metrics
- provide UI for entering server URL and optional credentials and list containers
- add package manifest and readme for the iOS app

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `swift build --package-path ios_app` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6841b53a13bc832ebb0d8067ebe138c2